### PR TITLE
Add Restate MCP Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@restatedev/vercel-ai-middleware",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@restatedev/vercel-ai-middleware",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
         "@changesets/cli": "^2.29.5",
@@ -25,6 +25,7 @@
         "typescript-eslint": "^8.35.1"
       },
       "peerDependencies": {
+        "@ai-sdk/mcp": "^1.0.10",
         "@restatedev/restate-sdk": "^1.10.2",
         "ai": "^6.0.41",
         "superjson": "^2.2.2"
@@ -40,6 +41,55 @@
         "@ai-sdk/provider": "3.0.4",
         "@ai-sdk/provider-utils": "4.0.8",
         "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.13.tgz",
+      "integrity": "sha512-yQEa+X5/QNmWlNwURAMlobmipvg4i/3L0iTz7pJQ/Z2Imjgp/y8gRAxkIzXL1HzlOxF4Dm/4PHpHrXaSV+EAUQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.5",
+        "@ai-sdk/provider-utils": "4.0.9",
+        "pkce-challenge": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.5.tgz",
+      "integrity": "sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.9.tgz",
+      "integrity": "sha512-bB4r6nfhBOpmoS9mePxjRoCy+LnzP3AfhyMGCkGL4Mn9clVNlqEeKj26zEKEtB6yoSVcT1IQ0Zh9fytwMCDnow==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.5",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -5609,6 +5659,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "peerDependencies": {
     "@restatedev/restate-sdk": "^1.10.2",
     "ai": "^6.0.41",
+    "@ai-sdk/mcp": "^1.0.10",
     "superjson": "^2.2.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "typescript-eslint": "^8.35.1"
   },
   "peerDependencies": {
+    "@ai-sdk/mcp": "^1.0.10",
     "@restatedev/restate-sdk": "^1.10.2",
     "ai": "^6.0.41",
-    "@ai-sdk/mcp": "^1.0.10",
     "superjson": "^2.2.2"
   },
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ export {
   getTerminalToolSteps,
   rethrowTerminalToolError,
 } from './lib/ai_infra';
+export {
+  createRestateMCPClient,
+  RestateMCPClient
+} from './lib/mcp_client'
 export type {
   Context,
   RunOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,7 @@ export {
   getTerminalToolSteps,
   rethrowTerminalToolError,
 } from './lib/ai_infra';
-export {
-  createRestateMCPClient,
-  RestateMCPClient
-} from './lib/mcp_client'
+export { createRestateMCPClient, RestateMCPClient } from './lib/mcp_client';
 export type {
   Context,
   RunOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,18 @@ export {
   getTerminalToolSteps,
   rethrowTerminalToolError,
 } from './lib/ai_infra';
-export { createRestateMCPClient, RestateMCPClient } from './lib/mcp_client';
+export {
+  createRestateMCPClient,
+  RestateMCPClient,
+  type ToolSchemas,
+  type ListResourcesResult,
+  type PaginatedRequest,
+  type RequestOptions,
+  type ReadResourceResult,
+  type ListResourceTemplatesResult,
+  type ListPromptsResult,
+  type GetPromptResult,
+} from './lib/mcp_client';
 export type {
   Context,
   RunOptions,

--- a/src/lib/mcp_client.ts
+++ b/src/lib/mcp_client.ts
@@ -61,6 +61,7 @@ export async function createRestateMCPClient(
   );
 }
 
+
 /**
  * MCP Client that wraps all server calls in Restate's ctx.run for durability and observability.
  *
@@ -88,14 +89,14 @@ export class RestateMCPClient {
   /**
    * Get tools from the MCP server, wrapped in ctx.run for durability
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async tools<TOOL_SCHEMAS extends ToolSchemas = 'automatic'>(options?: {
     schemas?: TOOL_SCHEMAS;
-  }) {
-    const tools = (await this.ctx.run(
+  }): Promise<Record<string, any>> {
+    const tools = await this.ctx.run(
       `${this.name}-mcp-list-tools`,
       async () => await this.client.tools(options),
-    ));
-
+    );
     return Object.fromEntries(
       Object.entries(tools).map(([toolName, toolResult]) => [
         toolName,

--- a/src/lib/mcp_client.ts
+++ b/src/lib/mcp_client.ts
@@ -88,9 +88,9 @@ export class RestateMCPClient {
   /**
    * Get tools from the MCP server, wrapped in ctx.run for durability
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async tools<TOOL_SCHEMAS extends ToolSchemas = 'automatic'>(options?: {
     schemas?: TOOL_SCHEMAS;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }): Promise<Record<string, any>> {
     const tools = await this.ctx.run(
       `${this.name}-mcp-list-tools`,

--- a/src/lib/mcp_client.ts
+++ b/src/lib/mcp_client.ts
@@ -61,7 +61,6 @@ export async function createRestateMCPClient(
   );
 }
 
-
 /**
  * MCP Client that wraps all server calls in Restate's ctx.run for durability and observability.
  *

--- a/src/lib/mcp_client.ts
+++ b/src/lib/mcp_client.ts
@@ -1,13 +1,19 @@
-import * as restate from '@restatedev/restate-sdk';
 import {
   createMCPClient,
   type MCPClient,
   type MCPClientConfig,
 } from '@ai-sdk/mcp';
 import { AISDKError, type ToolExecutionOptions } from 'ai';
-import { type RunOptions, TerminalError } from '@restatedev/restate-sdk';
-// Extract all types from the MCPClient interface since they're not exported
-type ToolSchemas =
+import {
+  type Context,
+  type RunOptions,
+  TerminalError,
+} from '@restatedev/restate-sdk';
+
+// Extract types from the MCPClient interface since they're not exported by @ai-sdk/mcp
+// These are exported so consumers can use them in their own type annotations
+
+export type ToolSchemas =
   | Record<
       string,
       {
@@ -16,28 +22,34 @@ type ToolSchemas =
     >
   | 'automatic'
   | undefined;
-type PaginatedRequest = Parameters<MCPClient['listResources']>[0] extends {
+export type PaginatedRequest = Parameters<
+  MCPClient['listResources']
+>[0] extends {
   params?: infer P;
 }
   ? { params: P }
   : never;
-type RequestOptions = Parameters<MCPClient['listResources']>[0] extends {
+export type RequestOptions = Parameters<MCPClient['listResources']>[0] extends {
   options?: infer O;
 }
   ? O
   : never;
-type ListResourcesResult = Awaited<ReturnType<MCPClient['listResources']>>;
-type ReadResourceResult = Awaited<ReturnType<MCPClient['readResource']>>;
-type ListResourceTemplatesResult = Awaited<
+export type ListResourcesResult = Awaited<
+  ReturnType<MCPClient['listResources']>
+>;
+export type ReadResourceResult = Awaited<ReturnType<MCPClient['readResource']>>;
+export type ListResourceTemplatesResult = Awaited<
   ReturnType<MCPClient['listResourceTemplates']>
 >;
-type ListPromptsResult = Awaited<
+export type ListPromptsResult = Awaited<
   ReturnType<MCPClient['experimental_listPrompts']>
 >;
-type GetPromptResult = Awaited<ReturnType<MCPClient['experimental_getPrompt']>>;
+export type GetPromptResult = Awaited<
+  ReturnType<MCPClient['experimental_getPrompt']>
+>;
 
 export async function createRestateMCPClient(
-  ctx: restate.Context,
+  ctx: Context,
   config: MCPClientConfig,
   runOptions?: RunOptions<never>,
 ) {
@@ -69,12 +81,12 @@ export async function createRestateMCPClient(
  */
 export class RestateMCPClient {
   private readonly client: MCPClient;
-  private readonly ctx: restate.Context;
+  private readonly ctx: Context;
   private readonly name: string;
   private readonly retryPolicy: RunOptions<never>;
 
   constructor(
-    ctx: restate.Context,
+    ctx: Context,
     name: string,
     client: MCPClient,
     retryPolicy: RunOptions<never>,

--- a/src/lib/mcp_client.ts
+++ b/src/lib/mcp_client.ts
@@ -1,0 +1,284 @@
+import * as restate from '@restatedev/restate-sdk';
+import {
+  createMCPClient,
+  type MCPClient,
+  type MCPClientConfig,
+} from '@ai-sdk/mcp';
+import { AISDKError, type ToolExecutionOptions } from 'ai';
+import { type RunOptions, TerminalError } from '@restatedev/restate-sdk';
+// Extract all types from the MCPClient interface since they're not exported
+type ToolSchemas =
+  | Record<
+      string,
+      {
+        inputSchema: never;
+      }
+    >
+  | 'automatic'
+  | undefined;
+type PaginatedRequest = Parameters<MCPClient['listResources']>[0] extends {
+  params?: infer P;
+}
+  ? { params: P }
+  : never;
+type RequestOptions = Parameters<MCPClient['listResources']>[0] extends {
+  options?: infer O;
+}
+  ? O
+  : never;
+type ListResourcesResult = Awaited<ReturnType<MCPClient['listResources']>>;
+type ReadResourceResult = Awaited<ReturnType<MCPClient['readResource']>>;
+type ListResourceTemplatesResult = Awaited<
+  ReturnType<MCPClient['listResourceTemplates']>
+>;
+type ListPromptsResult = Awaited<
+  ReturnType<MCPClient['experimental_listPrompts']>
+>;
+type GetPromptResult = Awaited<ReturnType<MCPClient['experimental_getPrompt']>>;
+
+export async function createRestateMCPClient(
+  ctx: restate.Context,
+  config: MCPClientConfig,
+  runOptions?: RunOptions<never>,
+) {
+  // check if transport is regular HTTP
+  if (!('type' in config.transport) || config.transport.type !== 'http') {
+    throw new TerminalError(
+      'RestateMCPClient only supports HTTP transport. No SSE or stdin/out transports are supported.',
+    );
+  }
+  const retryPolicy = runOptions || {
+    initialRetryInterval: { milliseconds: 1000 },
+    maxRetryAttempts: 10,
+  };
+
+  const client = await createMCPClient(config);
+  return new RestateMCPClient(
+    ctx,
+    config.name ?? 'RestateMCPClient',
+    client,
+    retryPolicy,
+  );
+}
+
+/**
+ * MCP Client that wraps all server calls in Restate's ctx.run for durability and observability.
+ *
+ * This wrapper ensures that all MCP server interactions are properly tracked and can be
+ * replayed in case of failures when using Restate workflows.
+ */
+export class RestateMCPClient {
+  private readonly client: MCPClient;
+  private readonly ctx: restate.Context;
+  private readonly name: string;
+  private readonly retryPolicy: RunOptions<never>;
+
+  constructor(
+    ctx: restate.Context,
+    name: string,
+    client: MCPClient,
+    retryPolicy: RunOptions<never>,
+  ) {
+    this.client = client;
+    this.name = name;
+    this.ctx = ctx;
+    this.retryPolicy = retryPolicy;
+  }
+
+  /**
+   * Get tools from the MCP server, wrapped in ctx.run for durability
+   */
+  async tools<TOOL_SCHEMAS extends ToolSchemas = 'automatic'>(options?: {
+    schemas?: TOOL_SCHEMAS;
+  }) {
+    const tools = (await this.ctx.run(
+      `${this.name}-mcp-list-tools`,
+      async () => await this.client.tools(options),
+    ));
+
+    return Object.fromEntries(
+      Object.entries(tools).map(([toolName, toolResult]) => [
+        toolName,
+        {
+          description: toolResult.description,
+          execute: async (input: unknown, options: ToolExecutionOptions) => {
+            return this.ctx.run(
+              `${toolName}-mcp-tool-execute`,
+              async () => {
+                // Retrieve tools again to get access to the execute function
+                const toolDefs = await this.client.tools();
+                const tool = toolDefs[toolName];
+                if (!tool) {
+                  throw new TerminalError(`Tool ${toolName} not found`);
+                }
+                try {
+                  return await tool.execute(input, options);
+                } catch (error) {
+                  if (isMCPClientError(error)) {
+                    throw new TerminalError(
+                      `${error.name} - ${error.message}`,
+                      {
+                        cause: error.cause,
+                      },
+                    );
+                  }
+                  throw error;
+                }
+              },
+              this.retryPolicy,
+            );
+          },
+          inputSchema: {
+            ...toolResult.inputSchema,
+            _type: undefined,
+            validate: undefined,
+            [Symbol.for('vercel.ai.schema')]: true,
+            [Symbol.for('vercel.ai.validator')]: true,
+          },
+          type: 'dynamic',
+        },
+      ]),
+    );
+  }
+
+  /**
+   * List resources from the MCP server, wrapped in ctx.run for durability
+   */
+  async listResources(options?: {
+    params?: PaginatedRequest['params'];
+    options?: RequestOptions;
+  }): Promise<ListResourcesResult> {
+    return this.ctx.run(
+      `${this.name}-mcp-list-resources`,
+      async () => {
+        try {
+          return await this.client.listResources(options);
+        } catch (error) {
+          if (isMCPClientError(error)) {
+            // For example client closed, unparsable response, etc.
+            throw new TerminalError(`${error.name} - ${error.message}`, {
+              cause: error.cause,
+            });
+          }
+          throw error;
+        }
+      },
+      this.retryPolicy,
+    );
+  }
+
+  /**
+   * Read a specific resource from the MCP server, wrapped in ctx.run for durability
+   */
+  async readResource(args: {
+    uri: string;
+    options?: RequestOptions;
+  }): Promise<ReadResourceResult> {
+    return this.ctx.run(
+      `${this.name}-mcp-read-resource-${args.uri}`,
+      async () => {
+        try {
+          return await this.client.readResource(args);
+        } catch (error) {
+          if (isMCPClientError(error)) {
+            // For example client closed, unparsable response, etc.
+            throw new TerminalError(`${error.name} - ${error.message}`, {
+              cause: error.cause,
+            });
+          }
+          throw error;
+        }
+      },
+      this.retryPolicy,
+    );
+  }
+
+  /**
+   * List resource templates from the MCP server, wrapped in ctx.run for durability
+   */
+  async listResourceTemplates(options?: {
+    options?: RequestOptions;
+  }): Promise<ListResourceTemplatesResult> {
+    return this.ctx.run(
+      `${this.name}-mcp-list-resource-templates`,
+      async () => {
+        try {
+          return await this.client.listResourceTemplates(options);
+        } catch (error) {
+          if (isMCPClientError(error)) {
+            // For example client closed, unparsable response, etc.
+            throw new TerminalError(`${error.name} - ${error.message}`, {
+              cause: error.cause,
+            });
+          }
+          throw error;
+        }
+      },
+      this.retryPolicy,
+    );
+  }
+
+  /**
+   * List prompts from the MCP server, wrapped in ctx.run for durability
+   */
+  async experimental_listPrompts(options?: {
+    params?: PaginatedRequest['params'];
+    options?: RequestOptions;
+  }): Promise<ListPromptsResult> {
+    return this.ctx.run(
+      `${this.name}-mcp-list-prompts`,
+      async () => {
+        try {
+          return await this.client.experimental_listPrompts(options);
+        } catch (error) {
+          if (isMCPClientError(error)) {
+            // For example client closed, unparsable response, etc.
+            throw new TerminalError(`${error.name} - ${error.message}`, {
+              cause: error.cause,
+            });
+          }
+          throw error;
+        }
+      },
+      this.retryPolicy,
+    );
+  }
+
+  /**
+   * Get a specific prompt from the MCP server, wrapped in ctx.run for durability
+   */
+  async experimental_getPrompt(args: {
+    name: string;
+    arguments?: Record<string, unknown>;
+    options?: RequestOptions;
+  }): Promise<GetPromptResult> {
+    return this.ctx.run(
+      `${this.name}-mcp-get-prompt-${args.name}`,
+      async () => {
+        try {
+          return await this.client.experimental_getPrompt(args);
+        } catch (error) {
+          if (isMCPClientError(error)) {
+            // For example client closed, unparsable response, etc.
+            throw new TerminalError(`${error.name} - ${error.message}`, {
+              cause: error.cause,
+            });
+          }
+          throw error;
+        }
+      },
+      this.retryPolicy,
+    );
+  }
+
+  /**
+   * Close the MCP client connection, wrapped in ctx.run for durability
+   */
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+}
+
+function isMCPClientError(error: unknown): error is AISDKError {
+  return AISDKError.isInstance(error) && error.name == 'MCPClientError';
+}


### PR DESCRIPTION
This pull request introduces a new integration with the MCP (Model Context Protocol) client into our codebase, providing a durable and observable wrapper for MCP operations within Restate workflows. The main focus is on making MCP server interactions robust and easily trackable by leveraging Restate's context management. The changes also expose the new client for external use and add the necessary dependencies.

**MCP Client Integration:**

* Added a new `RestateMCPClient` class in `src/lib/mcp_client.ts` that wraps MCP client operations (such as listing tools, resources, templates, and prompts) in `ctx.run` for durability and observability. This ensures all MCP server interactions are tracked and can be replayed in Restate workflows. Also includes error handling to surface MCP client errors as `TerminalError`s.
* Added a `createRestateMCPClient` factory function to instantiate the `RestateMCPClient` with proper configuration and retry policies, supporting only HTTP transport.

**Public API and Dependency Updates:**

* Exported `createRestateMCPClient` and `RestateMCPClient` from the main module (`src/index.ts`) to make the new client available to users.
* Added the `@ai-sdk/mcp` package as a peer dependency in `package.json` to support the new MCP client integration.