### PR TITLE
Upgrade to Vercel AI SDK 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@restatedev/vercel-ai-middleware",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@restatedev/vercel-ai-middleware",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
         "@changesets/cli": "^2.29.5",
@@ -24,75 +24,79 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.35.1"
       },
+      "engines": {
+        "node": ">=22"
+      },
       "peerDependencies": {
-        "@ai-sdk/mcp": "1.0.14",
+        "@ai-sdk/mcp": "2.0.1",
         "@restatedev/restate-sdk": "^1.10.2",
-        "ai": "6.0.52",
+        "ai": "7.0.2",
         "superjson": "^2.2.2"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.24.tgz",
-      "integrity": "sha512-gf8AsKMZWlAQBbTYEUyj57AGmmpqXxY3iytVz4KBD2pRYsEPEHDpdLbSnYcYP06U60j6HeJTgkeaIjHxezvtEw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.2.tgz",
+      "integrity": "sha512-Jz1BiiTSvhDsCBJrkFRSqLHDRMVjFtYk9GdbSi3UOqY+/epza+oIESMDzfN4m+YHT/1IYmNEmxaMfjXOvxKDjQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.5",
-        "@ai-sdk/provider-utils": "4.0.10",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "4.0.0",
+        "@ai-sdk/provider-utils": "5.0.0",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/mcp": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.14.tgz",
-      "integrity": "sha512-Rv8dORNPHH9RddwHfxBf9IBPSgmKa9YsWxnfH24PgnocDFE26Abqq8gPGMmFtN6gjZmC7qGrfqxTww+/dTtMCg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.1.tgz",
+      "integrity": "sha512-tsk+FAX7TN8BsA3eqwR7jf33PiYaGh+w/rHofk7hj13mFvicAhrdITgSOvncULUReUZcDoS0axHEXv1y1/yR8Q==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.5",
-        "@ai-sdk/provider-utils": "4.0.10",
-        "pkce-challenge": "^5.0.0"
+        "@ai-sdk/provider": "4.0.0",
+        "@ai-sdk/provider-utils": "5.0.0",
+        "pkce-challenge": "^5.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.5.tgz",
-      "integrity": "sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.0.tgz",
+      "integrity": "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.10.tgz",
-      "integrity": "sha512-VeDAiCH+ZK8Xs4hb9Cw7pHlujWNL52RKe8TExOkrw6Ir1AmfajBZTb9XUdKOZO08RwQElIKA8+Ltm+Gqfo8djQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.0.tgz",
+      "integrity": "sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.5",
+        "@ai-sdk/provider": "4.0.0",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -1657,16 +1661,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2488,14 +2482,21 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -2521,19 +2522,18 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.52",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.52.tgz",
-      "integrity": "sha512-vw+i+a43iKQ6fzCHn+tBEEcaIYZUbwJEw+BaBOyHuj/ypd/ZQFlzhJB5EfsNEOxucclFI7WsXV5AoyqI+9ihqA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.2.tgz",
+      "integrity": "sha512-VMU08jHIDJnnKDrbC9AFa5ZsPpOTfAPRLvTRHtJk4FGAoeldmJROMxvZ2ak5lCjEJ2GP2OLPQbMRyEK8w0+S4A==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.24",
-        "@ai-sdk/provider": "3.0.5",
-        "@ai-sdk/provider-utils": "4.0.10",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "4.0.2",
+        "@ai-sdk/provider": "4.0.0",
+        "@ai-sdk/provider-utils": "5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -3546,9 +3546,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -34,10 +34,13 @@
     "typescript-eslint": "^8.35.1"
   },
   "peerDependencies": {
-    "@ai-sdk/mcp": "1.0.14",
+    "@ai-sdk/mcp": "2.0.1",
     "@restatedev/restate-sdk": "^1.10.2",
-    "ai": "6.0.52",
+    "ai": "7.0.2",
     "superjson": "^2.2.2"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsup",

--- a/src/lib/ai_infra.ts
+++ b/src/lib/ai_infra.ts
@@ -5,15 +5,15 @@ import {
   TerminalError,
 } from '@restatedev/restate-sdk';
 import type {
-  LanguageModelV3,
-  LanguageModelV3Middleware,
+  LanguageModelV4,
+  LanguageModelV4Middleware,
 } from '@ai-sdk/provider';
 
 import superjson from 'superjson';
 import { type StepResult, type TypedToolError, type ToolSet } from 'ai';
 
 export type DoGenerateResponseType = Awaited<
-  ReturnType<LanguageModelV3['doGenerate']>
+  ReturnType<LanguageModelV4['doGenerate']>
 >;
 
 export class SuperJsonSerde<T> implements Serde<T> {
@@ -35,22 +35,22 @@ export const superJson = new SuperJsonSerde<any>();
 
 /**
  * The following function is a middleware that provides durability to the results of a
- * `doGenerate` method of a LanguageModelV1 instance.
+ * `doGenerate` method of a LanguageModelV4 instance.
  * @param ctx the restate context used to capture the execution of the `doGenerate` method.
  * @param opts retry options for the `doGenerate` method.
- * @returns an LanguageModelV2Middleware that provides durability to the underlying model.
+ * @returns an LanguageModelV4Middleware that provides durability to the underlying model.
  */
 export const durableCalls = (
   ctx: Context,
   opts?: RunOptions<DoGenerateResponseType>,
-): LanguageModelV3Middleware => {
+): LanguageModelV4Middleware => {
   const runOpts = {
     serde: new SuperJsonSerde<DoGenerateResponseType>(),
     ...opts,
   };
 
   return {
-    specificationVersion: 'v3',
+    specificationVersion: 'v4',
     wrapGenerate: async ({ model, doGenerate }) =>
       ctx.run(`calling ${model.provider}`, async () => doGenerate(), runOpts),
   };

--- a/src/lib/mcp_client.ts
+++ b/src/lib/mcp_client.ts
@@ -85,7 +85,10 @@ export class RestateMCPClient {
         toolName,
         {
           description: toolResult.description,
-          execute: async (input: unknown, options: ToolExecutionOptions) => {
+          execute: async (
+            input: unknown,
+            options: ToolExecutionOptions<unknown>,
+          ) => {
             return this.ctx.run(
               `${toolName}-mcp-tool-execute`,
               async () => {


### PR DESCRIPTION
Migrates from AI SDK v6 to v7. This is a middleware-level package, so most v7 app-API breakage doesn't apply.

* Peer deps: `ai` `6.0.52` → `7.0.2`, `@ai-sdk/mcp` `1.0.14` → `2.0.1`; added `engines.node >= 22` (v7 requirement).
* Provider spec v3 → v4 in `ai_infra.ts` (`ai@7` requires V4 middleware): `*V3` types → `*V4`, `specificationVersion` `'v3'` → `'v4'`.
* `ToolExecutionOptions` is now generic — parametrized `<unknown>` in the MCP client wrapper.

Full `npm run ci` passes (build, format, attw, lint, api-extractor).